### PR TITLE
Add an agent check that reports if the ECS agent is connected or not.

### DIFF
--- a/checks.d/ecs.py
+++ b/checks.d/ecs.py
@@ -40,7 +40,7 @@ class ECS(AgentCheck):
         else:
             return self.service_check(SERVICE_CHECK, AgentCheck.WARNING)
 
-    def connect_to_region(region_name, **kwargs):
+    def connect_to_region(self, region_name, **kwargs):
         for region in regions():
             if region.name == region_name:
                 return region.connect(**kwargs)

--- a/checks.d/ecs.py
+++ b/checks.d/ecs.py
@@ -1,0 +1,51 @@
+# stdlib
+import requests
+
+# 3rd party
+from boto.regioninfo import get_regions
+from boto.ec2containerservice.layer1 import EC2ContainerServiceConnection
+
+# project
+from checks import AgentCheck
+
+# URL for the ECS introspection API: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html
+METADATA_URL = 'http://127.0.0.1:51678/v1/metadata'
+
+# The name of the service check we'll use to report agent connection status.
+SERVICE_CHECK = 'ecs.agent_connected'
+
+
+class ECS(AgentCheck):
+    """Tracks agent connection status
+    """
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+    def check(self, instance):
+        ecs = self.connect_to_region(instance.get('region'))
+
+        metadata = requests.get(METADATA_URL).json()
+        cluster = metadata.get('Cluster')
+        container_instance = metadata.get('ContainerInstanceArn')
+
+        desc = ecs.describe_container_instances(container_instance, cluster)
+        container_instances = desc.get('containerInstances')
+
+        if len(container_instances) == 0:
+            return self.service_check(SERVICE_CHECK, AgentCheck.UNKNOWN)
+        if container_instances[0].get('agentConnected') == True:
+            return self.service_check(SERVICE_CHECK, AgentCheck.OK)
+        else:
+            return self.service_check(SERVICE_CHECK, AgentCheck.WARNING)
+
+    def connect_to_region(region_name, **kw_params):
+        for region in regions():
+            if region.name == region_name:
+                return region.connect(**kw_params)
+        return None
+
+# Unfortunately, the stable release of boto doesn't include https://github.com/boto/boto/pull/3143.
+def regions():
+    return get_regions('ec2containerservice', connection_cls=EC2ContainerServiceConnection)
+

--- a/checks.d/ecs.py
+++ b/checks.d/ecs.py
@@ -15,37 +15,33 @@ METADATA_URL = 'http://127.0.0.1:51678/v1/metadata'
 SERVICE_CHECK = 'ecs.agent_connected'
 
 
+# Unfortunately, the stable release of boto doesn't include https://github.com/boto/boto/pull/3143.
+def regions():
+    return get_regions('ec2containerservice', connection_cls=EC2ContainerServiceConnection)
+
 class ECS(AgentCheck):
     """Tracks agent connection status
     """
-
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
     def check(self, instance):
         ecs = self.connect_to_region(instance.get('region'))
 
         metadata = requests.get(METADATA_URL).json()
         cluster = metadata.get('Cluster')
-        container_instance = metadata.get('ContainerInstanceArn')
+        container_instance = metadata['ContainerInstanceArn']
 
         desc = ecs.describe_container_instances(container_instance, cluster)
-        container_instances = desc.get('containerInstances')
+        container_instances = desc['containerInstances']
 
-        if len(container_instances) == 0:
+        if not container_instances:
             return self.service_check(SERVICE_CHECK, AgentCheck.UNKNOWN)
-        if container_instances[0].get('agentConnected') == True:
+        if container_instances[0].get('agentConnected'):
             return self.service_check(SERVICE_CHECK, AgentCheck.OK)
         else:
             return self.service_check(SERVICE_CHECK, AgentCheck.WARNING)
 
-    def connect_to_region(region_name, **kw_params):
+    def connect_to_region(region_name, **kwargs):
         for region in regions():
             if region.name == region_name:
-                return region.connect(**kw_params)
+                return region.connect(**kwargs)
         return None
-
-# Unfortunately, the stable release of boto doesn't include https://github.com/boto/boto/pull/3143.
-def regions():
-    return get_regions('ec2containerservice', connection_cls=EC2ContainerServiceConnection)
-

--- a/checks.d/ecs.py
+++ b/checks.d/ecs.py
@@ -26,19 +26,22 @@ class ECS(AgentCheck):
     def check(self, instance):
         ecs = self.connect_to_region(instance.get('region'))
 
-        metadata = requests.get(METADATA_URL).json()
-        cluster = metadata.get('Cluster')
-        container_instance = metadata['ContainerInstanceArn']
+        try:
+            metadata = requests.get(METADATA_URL).json()
+            cluster = metadata.get('Cluster')
+            container_instance = metadata['ContainerInstanceArn']
 
-        desc = ecs.describe_container_instances(container_instance, cluster)
-        container_instances = desc['DescribeContainerInstancesResponse']['DescribeContainerInstancesResult']['containerInstances']
+            desc = ecs.describe_container_instances(container_instance, cluster)
+            container_instances = desc['DescribeContainerInstancesResponse']['DescribeContainerInstancesResult']['containerInstances']
 
-        if not container_instances:
-            return self.service_check(SERVICE_CHECK, AgentCheck.UNKNOWN)
-        if container_instances[0].get('agentConnected'):
-            return self.service_check(SERVICE_CHECK, AgentCheck.OK)
-        else:
-            return self.service_check(SERVICE_CHECK, AgentCheck.WARNING)
+            if not container_instances:
+                return self.service_check(SERVICE_CHECK, AgentCheck.UNKNOWN)
+            if container_instances[0].get('agentConnected'):
+                return self.service_check(SERVICE_CHECK, AgentCheck.OK)
+            else:
+                return self.service_check(SERVICE_CHECK, AgentCheck.WARNING)
+        except:
+            return self.service_check(SERVICE_CHECK, AgentCheck.CRITICAL)
 
     def connect_to_region(self, region_name, **kwargs):
         for region in regions():

--- a/checks.d/ecs.py
+++ b/checks.d/ecs.py
@@ -31,7 +31,7 @@ class ECS(AgentCheck):
         container_instance = metadata['ContainerInstanceArn']
 
         desc = ecs.describe_container_instances(container_instance, cluster)
-        container_instances = desc['containerInstances']
+        container_instances = desc['DescribeContainerInstancesResponse']['DescribeContainerInstancesResult']['containerInstances']
 
         if not container_instances:
             return self.service_check(SERVICE_CHECK, AgentCheck.UNKNOWN)

--- a/conf.d/ecs.yaml.example
+++ b/conf.d/ecs.yaml.example
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - 
+    # The AWS region to connect to.
+    region: us-east-1

--- a/tests/checks/mock/test_ecs.py
+++ b/tests/checks/mock/test_ecs.py
@@ -1,0 +1,65 @@
+# 3rd party
+import mock
+import json
+
+from tests.checks.common import AgentCheckTest, load_check
+
+MOCK_CONFIG = {
+    'init_config': {},
+    'instances' : [{
+        'region': 'us-east-1'
+    }]
+}
+
+def requests_get_mock(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, data, status_code):
+            self.data = data
+            self.status_code = status_code
+
+        def json(self):
+            return self.data
+
+        def raise_for_status(self):
+            return True
+
+    return MockResponse({
+        'Cluster': 'default',
+        'ContainerInstanceArn': 'arn:aws:ecs:us-east-1:012345678910:container-instance/c9c9a6f2-8766-464b-8805-9c57b9368fb0',
+    }, 200)
+
+class MockECSClient:
+    def __init__(self, container_instances):
+        self.container_instances = container_instances
+
+    def describe_container_instances(self, container_instances, cluster=None):
+        return {
+                'containerInstances': self.container_instances,
+                'failures': [] }
+
+class TestCheckECS(AgentCheckTest):
+    CHECK_NAME = 'ecs'
+
+    def mock_agent_connected(self, instance):
+        return MockECSClient([{ 'agentConnected': True, }])
+
+    def mock_agent_disconnected(self, instance):
+        return MockECSClient([{ 'agentConnected': False, }])
+
+    def mock_agent_not_found(self, instance):
+        return MockECSClient([])
+
+    @mock.patch('requests.get', side_effect=requests_get_mock)
+    def test_agent_connected(self, mock_requests):
+        self.run_check(MOCK_CONFIG, mocks={'connect_to_region': self.mock_agent_connected})
+        self.assertServiceCheckOK('ecs.agent_connected')
+
+    @mock.patch('requests.get', side_effect=requests_get_mock)
+    def test_agent_disconnected(self, mock_requests):
+        self.run_check(MOCK_CONFIG, mocks={'connect_to_region': self.mock_agent_disconnected})
+        self.assertServiceCheckWarning('ecs.agent_connected')
+
+    @mock.patch('requests.get', side_effect=requests_get_mock)
+    def test_agent_not_found(self, mock_requests):
+        self.run_check(MOCK_CONFIG, mocks={'connect_to_region': self.mock_agent_not_found})
+        self.assertServiceCheckUnknown('ecs.agent_connected')

--- a/tests/checks/mock/test_ecs.py
+++ b/tests/checks/mock/test_ecs.py
@@ -20,7 +20,10 @@ def mock_metadata_response(*args, **kwargs):
     return response
 
 def mock_connection_refused(*args, **kwargs):
-    raise IOError
+    raise TestFailed
+
+class TestFailed(Exception):
+    pass
 
 def mock_ecs_client(agent_connected=None):
     container_instances = []
@@ -62,5 +65,7 @@ class TestCheckECS(AgentCheckTest):
 
     @mock.patch('requests.get', side_effect=mock_connection_refused)
     def test_agent_not_running(self, mock_requests):
-        self.run_check(MOCK_CONFIG)
+        with self.assertRaises(TestFailed):
+            self.run_check(MOCK_CONFIG)
+
         self.assertServiceCheckCritical('ecs.agent_connected')

--- a/tests/checks/mock/test_ecs.py
+++ b/tests/checks/mock/test_ecs.py
@@ -65,7 +65,5 @@ class TestCheckECS(AgentCheckTest):
 
     @mock.patch('requests.get', side_effect=mock_connection_refused)
     def test_agent_not_running(self, mock_requests):
-        with self.assertRaises(TestFailed):
-            self.run_check(MOCK_CONFIG)
-
+        self.assertRaises(TestFailed, lambda: self.run_check(MOCK_CONFIG))
         self.assertServiceCheckCritical('ecs.agent_connected')

--- a/tests/checks/mock/test_ecs.py
+++ b/tests/checks/mock/test_ecs.py
@@ -25,7 +25,10 @@ def mock_ecs_client(agent_connected=None):
     if agent_connected is not None:
         container_instances.append({ 'agentConnected': agent_connected })
     mock_client = mock.Mock()
-    mock_client.describe_container_instances.return_value = { 'containerInstances': container_instances }
+    mock_client.describe_container_instances.return_value = {
+            'DescribeContainerInstancesResponse': {
+                'DescribeContainerInstancesResult': {
+                    'containerInstances': container_instances }}}
     return mock_client
 
 class TestCheckECS(AgentCheckTest):

--- a/tests/checks/mock/test_ecs.py
+++ b/tests/checks/mock/test_ecs.py
@@ -11,14 +11,16 @@ MOCK_CONFIG = {
     }]
 }
 
-def requests_get_mock(*args, **kwargs):
+def mock_metadata_response(*args, **kwargs):
     response = mock.Mock()
     response.status_code = 200
-    response.raise_for_status.return_value = True
     response.json.return_value = {
         'Cluster': 'default',
         'ContainerInstanceArn': 'arn:aws:ecs:us-east-1:012345678910:container-instance/c9c9a6f2-8766-464b-8805-9c57b9368fb0' }
     return response
+
+def mock_connection_refused(*args, **kwargs):
+    raise IOError
 
 def mock_ecs_client(agent_connected=None):
     container_instances = []
@@ -43,17 +45,22 @@ class TestCheckECS(AgentCheckTest):
     def mock_agent_not_found(self, instance):
         return mock_ecs_client()
 
-    @mock.patch('requests.get', side_effect=requests_get_mock)
+    @mock.patch('requests.get', side_effect=mock_metadata_response)
     def test_agent_connected(self, mock_requests):
         self.run_check(MOCK_CONFIG, mocks={ 'connect_to_region': self.mock_agent_connected })
         self.assertServiceCheckOK('ecs.agent_connected')
 
-    @mock.patch('requests.get', side_effect=requests_get_mock)
+    @mock.patch('requests.get', side_effect=mock_metadata_response)
     def test_agent_disconnected(self, mock_requests):
         self.run_check(MOCK_CONFIG, mocks={ 'connect_to_region': self.mock_agent_disconnected })
         self.assertServiceCheckWarning('ecs.agent_connected')
 
-    @mock.patch('requests.get', side_effect=requests_get_mock)
+    @mock.patch('requests.get', side_effect=mock_metadata_response)
     def test_agent_not_found(self, mock_requests):
         self.run_check(MOCK_CONFIG, mocks={ 'connect_to_region': self.mock_agent_not_found })
         self.assertServiceCheckUnknown('ecs.agent_connected')
+
+    @mock.patch('requests.get', side_effect=mock_connection_refused)
+    def test_agent_not_running(self, mock_requests):
+        self.run_check(MOCK_CONFIG)
+        self.assertServiceCheckCritical('ecs.agent_connected')


### PR DESCRIPTION
This adds an **ecs** agent check, which uses the [DescribeContainerInstances](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeContainerInstances.html) api and the [ECS agent introspection API](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-introspection.html) to report whether the ECS agent is connected or not.

This would be enabled on the datadog agent on each individual container instance.