### PR TITLE
Add a dnsmasq check.

### DIFF
--- a/checks.d/dnsmasq.py
+++ b/checks.d/dnsmasq.py
@@ -1,0 +1,28 @@
+# stdlib
+import subprocess
+
+# project
+from checks import AgentCheck
+
+
+def query_txt(name):
+    """Queries the TXT record for a domain name using dig."""
+    return subprocess.Popen(['dig', '+short', 'chaos', 'txt', name], stdout=subprocess.PIPE).communicate()[0].strip()
+
+
+class Dnsmasq(AgentCheck):
+    """Scrapes statistics from the .bind domain in dnsmasq. Requires dnsmasq v2.69+"""
+
+    def check(self, instance):
+        self.gauge('dnsmasq.cachesize', self.value('cachesize.bind'))
+        self.gauge('dnsmasq.insertions', self.value('insertions.bind'))
+        self.gauge('dnsmasq.evictions', self.value('evictions.bind'))
+        self.gauge('dnsmasq.misses', self.value('misses.bind'))
+        self.gauge('dnsmasq.hits', self.value('hits.bind'))
+
+    def value(self, name):
+        """Queries a TXT record, then cleans the double quotes and converts it to an int"""
+        return int(self.query_txt(name).replace('"', ''))
+
+    def query_txt(self, name):
+        return query_txt(name)

--- a/tests/checks/mock/test_dnsmasq.py
+++ b/tests/checks/mock/test_dnsmasq.py
@@ -1,0 +1,18 @@
+from tests.checks.common import AgentCheckTest
+
+def mock_config():
+    return {'init_config': {}, 'instances': [{}]}
+
+def mock_query_txt(name):
+    return '"10"'
+
+class TestCheckDnsmasq(AgentCheckTest):
+    CHECK_NAME = 'dnsmasq'
+
+    def test_ok(self):
+        self.run_check(mock_config(), mocks={'query_txt': mock_query_txt})
+        self.assertMetric('dnsmasq.cachesize', value=10)
+        self.assertMetric('dnsmasq.insertions', value=10)
+        self.assertMetric('dnsmasq.evictions', value=10)
+        self.assertMetric('dnsmasq.misses', value=10)
+        self.assertMetric('dnsmasq.hits', value=10)


### PR DESCRIPTION
This adds a custom check that will scrape statistics from dnsmasq, according to the docs at http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html


> The cache statistics are also available in the DNS as answers to queries of class CHAOS and type TXT in domain bind. The domain names are cachesize.bind, insertions.bind, evictions.bind, misses.bind, hits.bind, auth.bind and servers.bind. An example command to query this, using the dig utility would be

> dig +short chaos txt cachesize.bind